### PR TITLE
Fix result sort order + in-game two line button

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ no-thanks:
     max-card: 35
     extra-cards: 9
     min-player-number: 2
-    max-player-number: 7
+    max-player-number: 8
     coins-map:
       1: 11
       2: 11
@@ -17,3 +17,4 @@ no-thanks:
       5: 11
       6: 9
       7: 7
+      8: 7

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ no-thanks:
     id: no-thanks-token
     name: no-thanks-name
   default-game-params:
-    default-coins-count: 7
+    default-coins-count: 6
     min-card: 3
     max-card: 35
     extra-cards: 9
@@ -17,4 +17,4 @@ no-thanks:
       5: 11
       6: 9
       7: 7
-      8: 7
+      8: 6

--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -73,7 +73,7 @@ textarea:focus, input:focus {
     font-family: 'Fredoka One', sans-serif;
     box-shadow: 2px 5px 0 rgba(36, 34, 125, 0.8);
     margin: auto;
-    padding: 0 20px;
+    padding: 0 10px;
 }
 
 .button:hover {

--- a/src/main/resources/static/js/render.js
+++ b/src/main/resources/static/js/render.js
@@ -248,7 +248,7 @@ function renderEndRoundScreen(results) {
     gameScreen.hide()
     $('#result-table').html('')
     $('#result-screen').show()
-    Object.values(results).sort((a, b) => b.totalScore - a.totalScore).forEach(addResultRow)
+    Object.values(results).sort((a, b) => a.totalScore - b.totalScore).forEach(addResultRow)
 }
 
 function addResultRow(playerResultValue) {


### PR DESCRIPTION
1) Results are now sorted in the ASCENDING order, not DESCENDING
2) In-game buttons' text was carried to a new line on mobile with a narrow screen (see screenshot). Fixed by narrowing the padding.
![photo_2024-02-25_10-17-38](https://github.com/EkspoMurinoIndustries/no-thanks/assets/70219831/1563753a-25c9-4d06-8ed9-cb755dbd840b)
